### PR TITLE
Add MBIDs and release metadata

### DIFF
--- a/pkg/models/models.go
+++ b/pkg/models/models.go
@@ -26,13 +26,16 @@ type Format struct {
 
 type Release struct {
 	ID      int64
+	MBID    string
 	Title   string
+	Year    int
 	Tracks  []Track
 	Artists []Artist `gorm:"many2many:user_languages;"`
 }
 
 type Track struct {
 	ID        int64
+	MBID      string
 	Title     string
 	Position  int
 	Disc      int


### PR DESCRIPTION
This adds the MBID to both tracks and releases, as well as, adding
metadata to the release when uploaded from an archive.